### PR TITLE
Support to build on MinGW

### DIFF
--- a/toml.c
+++ b/toml.c
@@ -37,7 +37,11 @@ SOFTWARE.
 char* strndup(const char* s, size_t n)
 {
     size_t len = strnlen(s, n);
+#ifdef __GNUC__
+    char* p = calloc(len+1, sizeof(const char*));
+#else
     char* p = malloc(s, len+1);
+#endif
     if (p) {
 	memcpy(p, s, len);
 	p[len] = 0;


### PR DESCRIPTION
Mingw is defining _WIN32. Thus, it uses strndup function which is written in toml.c. But it shows error because number of argument for malloc function argument is different from MSVC.
Mingw shows error strndup function does not found if I made mingw gcc does not use strndup for _WIN32
As the result, I added check code with __GNUC__ function