### PR TITLE
Fix toml_cat abort on empty array

### DIFF
--- a/toml_cat.c
+++ b/toml_cat.c
@@ -141,6 +141,9 @@ static void print_array(toml_array_t* curarr)
 	printf("\n");
 	break;
 	
+    case '\0':
+	break;
+
     default:
 	abort();
     }


### PR DESCRIPTION
toml_array_ts don't get their type set until the first entry is added - toml_cat expects the type to be set, so breaks on a zero-length array.