### PR TITLE
Eliminate warnings when -Wcast-qual is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc 
 CFILES = toml.c
 
-CFLAGS = -std=c99 -Wall -Wextra 
+CFLAGS = -std=c99 -Wall -Wextra -Wcast-qual
 CFLAGS += -O2 -DNDEBUG
 #CFLAGS += -O0 -g
 

--- a/toml.c
+++ b/toml.c
@@ -263,7 +263,19 @@ struct toml_table_t {
 };
 
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
 static inline void xfree(const void* x) { if (x) free((void*)x); }
+#pragma clang diagnostic pop
+#elif __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+static inline void xfree(const void* x) { if (x) free((void*)x); }
+#pragma GCC diagnostic pop
+#else
+static inline void xfree(const void* x) { if (x) free((void*)x); }
+#endif
 
 
 enum tokentype_t {


### PR DESCRIPTION
The xfree() function is flagged as a warning by -Wcast-qual because it overrides the const-ness of it's argument. Removing this function, and similar xfree_*() calls, also requires changing "const char *" to "char *" in several data structures. IMHO, these are mutable pointers and should not be treated as constant.