### PR TITLE
Helperfuncs

### DIFF
--- a/toml.c
+++ b/toml.c
@@ -1615,6 +1615,11 @@ int toml_array_nelem(toml_array_t* arr)
     return arr->nelem;
 }
 
+const char* toml_array_key(toml_array_t* arr)
+{
+  return arr ? arr->key : (const char*) NULL;
+}
+
 int toml_table_nkval(toml_table_t* tab)
 {
   return tab->nkval;
@@ -1628,6 +1633,11 @@ int toml_table_narr(toml_table_t* tab)
 int toml_table_ntab(toml_table_t* tab)
 {
   return tab->ntab;
+}
+
+const char* toml_table_key(toml_table_t* tab)
+{
+  return tab ? tab->key : (const char*) NULL;
 }
 
 toml_array_t* toml_array_at(toml_array_t* arr, int idx)

--- a/toml.c
+++ b/toml.c
@@ -1610,6 +1610,11 @@ char toml_array_kind(toml_array_t* arr)
 }
 
 
+int toml_array_nelem(toml_array_t* arr)
+{
+    return arr->nelem;
+}
+
 int toml_table_nkval(toml_table_t* tab)
 {
   return tab->nkval;

--- a/toml.c
+++ b/toml.c
@@ -1610,6 +1610,20 @@ char toml_array_kind(toml_array_t* arr)
 }
 
 
+int toml_table_nkval(toml_table_t* tab)
+{
+  return tab->nkval;
+}
+
+int toml_table_narr(toml_table_t* tab)
+{
+  return tab->narr;
+}
+
+int toml_table_ntab(toml_table_t* tab)
+{
+  return tab->ntab;
+}
 
 toml_array_t* toml_array_at(toml_array_t* arr, int idx)
 {

--- a/toml.h
+++ b/toml.h
@@ -66,6 +66,9 @@ TOML_EXTERN char toml_array_kind(toml_array_t* arr);
 /* Return the number of elements in the array */
 TOML_EXTERN int toml_array_nelem(toml_array_t* arr);
 
+/* Return the key of an array */
+TOML_EXTERN const char* toml_array_key(toml_array_t* arr);
+
 /* Return the number of key-values in a table */
 TOML_EXTERN int toml_table_nkval(toml_table_t* tab);
 
@@ -74,6 +77,9 @@ TOML_EXTERN int toml_table_narr(toml_table_t* tab);
 
 /* Return the number of sub-tables in a table */
 TOML_EXTERN int toml_table_ntab(toml_table_t* tab);
+
+/* Return the key of a table*/
+TOML_EXTERN const char* toml_table_key(toml_table_t* tab);
 
 /* Deref array by index. Return the element at idx or 0 if out of range. */
 TOML_EXTERN const char* toml_raw_at(toml_array_t* arr, int idx);

--- a/toml.h
+++ b/toml.h
@@ -63,6 +63,15 @@ TOML_EXTERN toml_table_t* toml_table_in(toml_table_t* tab, const char* key);
 /* Return the array kind: 't'able, 'a'rray, 'v'alue */
 TOML_EXTERN char toml_array_kind(toml_array_t* arr);
 
+/* Return the number of key-values in a table */
+TOML_EXTERN int toml_table_nkval(toml_table_t* tab);
+
+/* Return the number of arrays in a table */
+TOML_EXTERN int toml_table_narr(toml_table_t* tab);
+
+/* Return the number of sub-tables in a table */
+TOML_EXTERN int toml_table_ntab(toml_table_t* tab);
+
 /* Deref array by index. Return the element at idx or 0 if out of range. */
 TOML_EXTERN const char* toml_raw_at(toml_array_t* arr, int idx);
 TOML_EXTERN toml_array_t* toml_array_at(toml_array_t* arr, int idx);

--- a/toml.h
+++ b/toml.h
@@ -63,6 +63,9 @@ TOML_EXTERN toml_table_t* toml_table_in(toml_table_t* tab, const char* key);
 /* Return the array kind: 't'able, 'a'rray, 'v'alue */
 TOML_EXTERN char toml_array_kind(toml_array_t* arr);
 
+/* Return the number of elements in the array */
+TOML_EXTERN int toml_array_nelem(toml_array_t* arr);
+
 /* Return the number of key-values in a table */
 TOML_EXTERN int toml_table_nkval(toml_table_t* tab);
 


### PR DESCRIPTION
Please consider adding the following helper functions.
I have broken them out into 3 commits grouping similar functionality.

The first commit (88eacb3) adds helper functions to get the `nkval`, `narr` and `ntab` member values of a `toml_table_t` struct.

The second commit (b53c016) adds a function to get the `nelem` member value of a `toml_array_t` struct.

The third commit (3fed0ab) adds functions to get the key value of `toml_array_t` and `toml_table_t` structs.

Thanks