### PR TITLE
Add rules for libtoml.so to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc 
 CFILES = toml.c
 
-CFLAGS = -std=c99 -Wall -Wextra 
+CFLAGS = -std=c99 -Wall -Wextra -fpic
 # to compile for debug: make DEBUG=1
 # to compile for no debug: make
 ifdef DEBUG
@@ -13,12 +13,16 @@ endif
 EXEC = toml_json toml_cat
 
 LIB = libtoml.a
+LIB_SHARED = libtoml.so
 
-all: $(LIB) $(EXEC)
+all: $(LIB) $(LIB_SHARED) $(EXEC)
 
 
 libtoml.a: toml.o
 	ar -rcs $@ $^
+
+libtoml.so: toml.o
+	$(CC) -shared -o $@ $^
 
 toml_json: toml_json.c $(LIB)
 
@@ -29,7 +33,8 @@ prefix ?= /usr/local
 install: all
 	install -d ${prefix}/include ${prefix}/lib
 	install toml.h ${prefix}/include
-	install libtoml.a ${prefix}/lib
+	install $(LIB) ${prefix}/lib
+	install $(LIB_SHARED) ${prefix}/lib
 
 clean:
-	rm -f *.o $(EXEC) $(LIB)
+	rm -f *.o $(EXEC) $(LIB) $(LIB_SHARED)


### PR DESCRIPTION
Just a straight-forward shared library target in the Makefile.