### PR TITLE
update gcc command to cc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC = gcc 
+CC = cc 
 CFILES = toml.c
 
 CFLAGS = -std=c99 -Wall -Wextra -fpic
@@ -38,3 +38,4 @@ install: all
 
 clean:
 	rm -f *.o $(EXEC) $(LIB) $(LIB_SHARED)
+


### PR DESCRIPTION
I work with a couple operating systems that don't use `gcc` and since `cc` is usually a symlink, I thought i might update this.  I'm happy for any feedback.  Thank you for this lib. I use it often and it's great.