### PR TITLE
Fix warning that dummy buffer is too small

### DIFF
--- a/toml.c
+++ b/toml.c
@@ -2089,7 +2089,7 @@ int toml_rtod(const char* src, double* ret_)
 
 int toml_rtos(const char* src, char** ret)
 {
-    char dummy_errbuf[1];
+    char dummy_errbuf[BUFSIZ];
 	int multiline = 0;
 	const char* sp;
 	const char* sq;


### PR DESCRIPTION
I encountered these warnings when building `tomlc99`:
```
../src/toml/toml.c: In function 'toml_rtos':
../src/toml/toml.c:418:46: warning: 'out of memory' directive output truncated writing 13 bytes into a region of size 1 [-Wformat-truncation=]
  418 |                 snprintf(errbuf, errbufsz, "out of memory");
      |                                             ~^~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from ../src/toml/toml.c:28:
/usr/include/bits/stdio2.h:67:10: note: '__builtin_snprintf' output 14 bytes into a destination of size 1
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/toml/toml.c:434:34: warning: 'invalid char U+' directive output truncated writing 15 bytes into a region of size 1 [-Wformat-truncation=]
  434 |     snprintf(errbuf, errbufsz, "invalid char U+%04x", ch);
      |                                 ~^~~~~~~~~~~~~~
../src/toml/toml.c:434:32: note: using the range [0, 4294967295] for directive argument
  434 |     snprintf(errbuf, errbufsz, "invalid char U+%04x", ch);
      |                                ^~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from ../src/toml/toml.c:28:
/usr/include/bits/stdio2.h:67:10: note: '__builtin___snprintf_chk' output between 20 and 24 bytes into a destination of size 1
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
These are all caused by `dummy_errbuf` in `toml_rtos` being too small, so I expanded it to `BUFSIZ`, although it currently only needs a max size of 24.