### PR TITLE
Whitespace cleanup

### DIFF
--- a/test1/build.sh
+++ b/test1/build.sh
@@ -2,7 +2,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 mkdir -p $DIR/goworkspace
-export GOPATH=$DIR/goworkspace 
+export GOPATH=$DIR/goworkspace
 go get github.com/BurntSushi/toml-test # install test suite
 go get github.com/BurntSushi/toml/cmd/toml-test-decoder # e.g., install my parser
 cp $GOPATH/bin/* .

--- a/test2/run.sh
+++ b/test2/run.sh
@@ -1,4 +1,4 @@
-if ! (which jq >& /dev/null); then 
+if ! (which jq >& /dev/null); then
     echo "ERROR: please install the 'jq' utility"
     exit 1
 fi
@@ -12,11 +12,11 @@ for i in toml-spec-tests/values/*.toml; do
     fname="${fname%.*}"
     echo -n $fname ' '
     res='[OK]'
-    if (../toml_json $fname.toml >& $fname.json.out); then 
+    if (../toml_json $fname.toml >& $fname.json.out); then
         jq -S . $fname.json.out > t.json
 	mv t.json $fname.json.out
 	if [ -f $fname.json ]; then
-	    if ! (diff $fname.json $fname.json.out >& /dev/null); then 
+	    if ! (diff $fname.json $fname.json.out >& /dev/null); then
 	        res='[FAILED]'
 	    else
 		rm -f $fname.json.out
@@ -32,10 +32,10 @@ done
 #
 #  NEGATIVE tests
 #
-for i in toml-spec-tests/errors/*.toml; do 
+for i in toml-spec-tests/errors/*.toml; do
     echo -n $i ' '
     res='[OK]'
-    if (../toml_json $i >& $i.json.out); then 
+    if (../toml_json $i >& $i.json.out); then
 	res='[FAILED]'
     fi
     echo ... $res

--- a/toml.h
+++ b/toml.h
@@ -1,19 +1,19 @@
 /*
   MIT License
-  
+
   Copyright (c) 2017 - 2019 CK Tan
   https://github.com/cktan/tomlc99
-  
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-  
+
   The above copyright notice and this permission notice shall be included in all
   copies or substantial portions of the Software.
-  
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,6 +22,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
+
 #ifndef TOML_H
 #define TOML_H
 
@@ -39,14 +40,14 @@
 typedef struct toml_table_t toml_table_t;
 typedef struct toml_array_t toml_array_t;
 
-/* Parse a file. Return a table on success, or 0 otherwise. 
+/* Parse a file. Return a table on success, or 0 otherwise.
  * Caller must toml_free(the-return-value) after use.
  */
-TOML_EXTERN toml_table_t* toml_parse_file(FILE* fp, 
+TOML_EXTERN toml_table_t* toml_parse_file(FILE* fp,
                                           char* errbuf,
                                           int errbufsz);
 
-/* Parse a string containing the full config. 
+/* Parse a string containing the full config.
  * Return a table on success, or 0 otherwise.
  * Caller must toml_free(the-return-value) after use.
  */
@@ -68,7 +69,7 @@ TOML_EXTERN toml_table_t* toml_table_in(toml_table_t* tab, const char* key);
 /* Return the array kind: 't'able, 'a'rray, 'v'alue */
 TOML_EXTERN char toml_array_kind(toml_array_t* arr);
 
-/* For array kind 'v'alue, return the type of values 
+/* For array kind 'v'alue, return the type of values
    i:int, d:double, b:bool, s:string, t:time, D:date, T:timestamp
    0 if unknown
 */
@@ -99,7 +100,7 @@ TOML_EXTERN toml_array_t* toml_array_at(toml_array_t* arr, int idx);
 TOML_EXTERN toml_table_t* toml_table_at(toml_array_t* arr, int idx);
 
 
-/* Raw to String. Caller must call free(ret) after use. 
+/* Raw to String. Caller must call free(ret) after use.
  * Return 0 on success, -1 otherwise.
  */
 TOML_EXTERN int toml_rtos(const char* s, char** ret);
@@ -115,7 +116,7 @@ TOML_EXTERN int toml_rtod(const char* s, double* ret);
 /* Same as toml_rtod, but return the sanitized double in string form as well */
 TOML_EXTERN int toml_rtod_ex(const char* s, double* ret, char* buf, int buflen);
 
-/* Timestamp types. The year, month, day, hour, minute, second, z 
+/* Timestamp types. The year, month, day, hour, minute, second, z
  * fields may be NULL if they are not relevant. e.g. In a DATE
  * type, the hour, minute, second and z fields will be NULLs.
  */

--- a/toml_cat.c
+++ b/toml_cat.c
@@ -1,26 +1,26 @@
 /*
-MIT License
+  MIT License
 
-Copyright (c) 2017 CK Tan
-https://github.com/cktan/tomlc99
+  Copyright (c) 2017 CK Tan
+  https://github.com/cktan/tomlc99
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
 */
 
 #ifdef NDEBUG
@@ -121,26 +121,26 @@ static void print_array(toml_array_t* curarr)
 
     switch (toml_array_kind(curarr)) {
 
-    case 'v': 
+    case 'v':
 	for (i = 0; 0 != (raw = toml_raw_at(curarr, i)); i++) {
 	    printf("  %d: %s,\n", i, raw);
 	}
 	break;
 
-    case 'a': 
+    case 'a':
 	for (i = 0; 0 != (arr = toml_array_at(curarr, i)); i++) {
 	    printf("  %d: \n", i);
 	    print_array(arr);
 	}
 	break;
-	    
-    case 't': 
+
+    case 't':
 	for (i = 0; 0 != (tab = toml_table_at(curarr, i)); i++) {
 	    print_table(tab);
 	}
 	printf("\n");
 	break;
-	
+
     case '\0':
 	break;
 
@@ -154,7 +154,7 @@ static void print_array(toml_array_t* curarr)
 static void cat(FILE* fp)
 {
     char  errbuf[200];
-    
+
     toml_table_t* tab = toml_parse_file(fp, errbuf, sizeof(errbuf));
     if (!tab) {
 	fprintf(stderr, "ERROR: %s\n", errbuf);
@@ -178,7 +178,7 @@ int main(int argc, const char* argv[])
 	cat(stdin);
     } else {
 	for (i = 1; i < argc; i++) {
-	    
+
 	    FILE* fp = fopen(argv[i], "r");
 	    if (!fp) {
 		fprintf(stderr, "ERROR: cannot open %s: %s\n",

--- a/toml_json.c
+++ b/toml_json.c
@@ -22,6 +22,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
   SOFTWARE.
 */
+
 #ifdef NDEBUG
 #undef NDEBUG
 #endif
@@ -112,7 +113,7 @@ static void print_table(toml_table_t* curtab)
 		printf("%s\"", i > 0 ? "," : "");
 		print_escape_string(key);
 		printf("\":");
-	
+
 		if (0 != (raw = toml_raw_in(curtab, key))) {
 			print_raw(raw);
 		} else if (0 != (arr = toml_array_in(curtab, key))) {
@@ -130,7 +131,7 @@ static void print_table_array(toml_array_t* curarr)
 {
 	int i;
 	toml_table_t* tab;
-	
+
 	printf("[");
 	for (i = 0; 0 != (tab = toml_table_at(curarr, i)); i++) {
 		printf("%s", i > 0 ? "," : "");
@@ -148,19 +149,19 @@ static void print_array(toml_array_t* curarr)
 	if (toml_array_kind(curarr) == 't') {
 		print_table_array(curarr);
 		return;
-	} 
+	}
 
 	printf("{\"type\":\"array\",\"value\":[");
 	switch (toml_array_kind(curarr)) {
 
-	case 'v': 
+	case 'v':
 		for (i = 0; 0 != (raw = toml_raw_at(curarr, i)); i++) {
 			printf("%s", i > 0 ? "," : "");
 			print_raw(raw);
 		}
 		break;
 
-	case 'a': 
+	case 'a':
 		for (i = 0; 0 != (arr = toml_array_at(curarr, i)); i++) {
 			printf("%s", i > 0 ? "," : "");
 			print_array(arr);
@@ -178,7 +179,7 @@ static void print_array(toml_array_t* curarr)
 static void cat(FILE* fp)
 {
 	char  errbuf[200];
-	
+
 	toml_table_t* tab = toml_parse_file(fp, errbuf, sizeof(errbuf));
 	if (!tab) {
 		fprintf(stderr, "ERROR: %s\n", errbuf);
@@ -199,7 +200,7 @@ int main(int argc, const char* argv[])
 		cat(stdin);
 	} else {
 		for (i = 1; i < argc; i++) {
-		
+
 			FILE* fp = fopen(argv[i], "r");
 			if (!fp) {
 				fprintf(stderr, "ERROR: cannot open %s: %s\n",

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -1,6 +1,6 @@
 CFLAGS = -g -I..
 
-TESTS = t1 
+TESTS = t1
 
 all: $(TESTS)
 

--- a/unittest/t1.c
+++ b/unittest/t1.c
@@ -5,34 +5,33 @@
 #include "../toml.h"
 
 
-
 int main(int argc, const char* argv[])
 {
     char    xxbuf[6], buf[6];
     int64_t xxcode, code;
     int     xxsize;
-    
-    
+
+
     xxsize = 2, xxcode = 0x80; memcpy(xxbuf, "\xc2\x80", xxsize);
     assert(toml_ucs_to_utf8(xxcode, buf) == xxsize && 0 == memcmp(buf, xxbuf, xxsize));
     assert(toml_utf8_to_ucs(buf, xxsize, &code) == xxsize && code == xxcode);
 
-    xxsize = 2, xxcode = 0x7ff; memcpy(xxbuf, "\xdf\xbf", xxsize); 
+    xxsize = 2, xxcode = 0x7ff; memcpy(xxbuf, "\xdf\xbf", xxsize);
     assert(toml_ucs_to_utf8(xxcode, buf) == xxsize && 0 == memcmp(buf, xxbuf, xxsize));
     assert(toml_utf8_to_ucs(buf, xxsize, &code) == xxsize && code == xxcode);
 
     xxsize = 3, xxcode = 0x800; memcpy(xxbuf, "\xe0\xa0\x80", xxsize);
     assert(toml_ucs_to_utf8(xxcode, buf) == xxsize && 0 == memcmp(buf, xxbuf, xxsize));
     assert(toml_utf8_to_ucs(buf, xxsize, &code) == xxsize && code == xxcode);
-    
+
     xxsize = 3, xxcode = 0xfffd; memcpy(xxbuf, "\xef\xbf\xbd", xxsize);
     assert(toml_ucs_to_utf8(xxcode, buf) == xxsize && 0 == memcmp(buf, xxbuf, xxsize));
     assert(toml_utf8_to_ucs(buf, xxsize, &code) == xxsize && code == xxcode);
-    
+
     xxsize = 4, xxcode = 0x10000; memcpy(xxbuf, "\xf0\x90\x80\x80", xxsize);
     assert(toml_ucs_to_utf8(xxcode, buf) == xxsize && 0 == memcmp(buf, xxbuf, xxsize));
     assert(toml_utf8_to_ucs(buf, xxsize, &code) == xxsize && code == xxcode);
-    
+
     xxsize = 4, xxcode = 0x1fffff; memcpy(xxbuf, "\xf7\xbf\xbf\xbf", xxsize);
     assert(toml_ucs_to_utf8(xxcode, buf) == xxsize && 0 == memcmp(buf, xxbuf, xxsize));
     assert(toml_utf8_to_ucs(buf, xxsize, &code) == xxsize && code == xxcode);
@@ -40,7 +39,7 @@ int main(int argc, const char* argv[])
     xxsize = 5, xxcode = 0x200000; memcpy(xxbuf, "\xf8\x88\x80\x80\x80", xxsize);
     assert(toml_ucs_to_utf8(xxcode, buf) == xxsize && 0 == memcmp(buf, xxbuf, xxsize));
     assert(toml_utf8_to_ucs(buf, xxsize, &code) == xxsize && code == xxcode);
-    
+
     xxsize = 5, xxcode = 0x3ffffff; memcpy(xxbuf, "\xfb\xbf\xbf\xbf\xbf", xxsize);
     assert(toml_ucs_to_utf8(xxcode, buf) == xxsize && 0 == memcmp(buf, xxbuf, xxsize));
     assert(toml_utf8_to_ucs(buf, xxsize, &code) == xxsize && code == xxcode);
@@ -54,4 +53,4 @@ int main(int argc, const char* argv[])
     assert(toml_utf8_to_ucs(buf, xxsize, &code) == xxsize && code == xxcode);
 
     return 0;
-}    
+}


### PR DESCRIPTION
Removes trailing whitespace and makes the spacing around licenses
consistent.