### PR TITLE
Only define memory defines if they are not already defined

### DIFF
--- a/toml.c
+++ b/toml.c
@@ -52,11 +52,18 @@ void toml_set_memutil(void* (*xxmalloc)(size_t),
 	pprealloc = xxrealloc;
 }
 
-
-#define MALLOC(a)     ppmalloc(a)
-#define FREE(a)       ppfree(a)
-#define CALLOC(a,b)   ppcalloc(a,b)
-#define REALLOC(a,b)  pprealloc(a,b)
+#ifndef MALLOC
+    #define MALLOC(a)     ppmalloc(a)
+#endif
+#ifndef FREE
+    #define FREE(a)       ppfree(a)
+#endif
+#ifndef CALLOC
+    #define CALLOC(a,b)   ppcalloc(a,b)
+#endif
+#ifndef REALLOC
+    #define REALLOC(a,b)  pprealloc(a,b)
+#endif
 
 char* STRDUP(const char* s)
 {


### PR DESCRIPTION
Without the ifdefs, the defaults will overwrite any predefined
definitions. That defeats the reason for the defines in the first place.

fixes issue #22