### PR TITLE
Fix truncation warning

### DIFF
--- a/toml.c
+++ b/toml.c
@@ -2089,7 +2089,7 @@ int toml_rtod(const char* src, double* ret_)
 
 int toml_rtos(const char* src, char** ret)
 {
-    char dummy_errbuf[1];
+    char dummy_errbuf[1024];
 	int multiline = 0;
 	const char* sp;
 	const char* sq;


### PR DESCRIPTION
```
toml.c:434:34: warning: ‘invalid char U+’ directive output truncated writing 15 bytes into a region of size 1 [-Wformat-truncation=]
     snprintf(errbuf, errbufsz, "invalid char U+%04x", ch);
```