### PR TITLE
Meson build system and subproject support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ convert it to a string or integer depending on context.
 A normal *make* suffices. Alternately, you can also simply include the
 `toml.c` and `toml.h` files in your project.
 
+If using the Meson build system, you can also include tomlc99 as a subproject,
+by adding the following to your `meson.build`:
+
+```
+    toml_dep = dependency('toml', fallback: ['tomlc99', 'toml_dep'])
+```
+
+And then add a git submodule in your `subprojects` directory:
+
+```
+   % cd subprojects
+   % git submodule add https://github.com/cktan/tomlc99.git
+```
+
 # Testing
 
 To test against the standard test set provided by BurntSushi/toml-test:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If using the Meson build system, you can also include tomlc99 as a subproject,
 by adding the following to your `meson.build`:
 
 ```
-    toml_dep = dependency('toml', fallback: ['tomlc99', 'toml_dep'])
+    toml_dep = dependency('tomlc99', fallback: ['tomlc99', 'toml_dep'])
 ```
 
 And then add a git submodule in your `subprojects` directory:

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,11 @@
+project('tomlc99', 'c', license: 'MIT')
+
+toml = library('toml',
+  ['toml.c', 'toml.h'],
+  install: true
+)
+install_headers('toml.h')
+toml_dep = declare_dependency(link_with: toml)
+
+executable('toml_json', 'toml_json.c', link_with: toml)
+executable('toml_cat',  'toml_cat.c',  link_with: toml)

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
 project('tomlc99', 'c', license: 'MIT')
+pkg = import('pkgconfig')
 
 toml = library('toml',
   ['toml.c', 'toml.h'],
@@ -9,3 +10,8 @@ toml_dep = declare_dependency(link_with: toml)
 
 executable('toml_json', 'toml_json.c', link_with: toml)
 executable('toml_cat',  'toml_cat.c',  link_with: toml)
+
+pkg.generate(toml,
+             name: meson.project_name(),
+             description: 'tomlc99 - TOML parser in C99',
+             url: 'https://github.com/cktan/tomlc99')


### PR DESCRIPTION
This PR adds a Meson build file. It allows using Meson to build both the library (static and/or shared) and the programs, makes tomlc99 usable as a Meson subproject and also automatically generates a pkg-config (.pc) file. This makes it easy to pull in the latest revision for Meson users. Thanks!