### PR TITLE
Remove use of REALLOC()

### DIFF
--- a/toml.h
+++ b/toml.h
@@ -144,7 +144,6 @@ TOML_EXTERN int toml_utf8_to_ucs(const char* orig, int len, int64_t* ret);
 TOML_EXTERN int toml_ucs_to_utf8(int64_t code, char buf[6]);
 TOML_EXTERN void toml_set_memutil(void* (*xxmalloc)(size_t),
 								  void	(*xxfree)(void*),
-								  void* (*xxcalloc)(size_t, size_t),
-								  void* (*xxrealloc)(void*, size_t));
+								  void* (*xxcalloc)(size_t, size_t));
 
 #endif /* TOML_H */


### PR DESCRIPTION
Note that all REALLOCs in the original code always expand the
previously allocated buffer by a known size, so it is easy to
memcpy() the previous data into the newly MALLOCed buffer.

This removes the dependency on realloc(). This in turn simplifies
porting to no-libc software.

Follow-up to issue #44. CC @dimakuv for the original implementation.