### PR TITLE
Port to VC6

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,6 +3,9 @@ MIT License
 Copyright (c) 2017 CK Tan
 https://github.com/cktan/tomlc99
 
+Copyright (c) 2021 Mir Drualga
+https://github.com/IAmTrial/tomlvc6
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFILES = toml.c
 OBJ = $(CFILES:.c=.o)
 EXEC = toml_json toml_cat toml_sample
 
-CFLAGS = -std=c99 -Wall -Wextra -fpic
+CFLAGS = -std=c89 -Wall -Wextra -fpic
 LIB_VERSION = 1.0
 LIB = libtoml.a
 LIB_SHARED = libtoml.so.$(LIB_VERSION)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# tomlc99
+# tomlvc6
 
-TOML in c99; v1.0 compliant.
+TOML for VC6 in C89; v1.0 compliant.
 
 If you are looking for a C++ library, you might try this wrapper: [https://github.com/cktan/tomlcpp](https://github.com/cktan/tomlcpp).
 

--- a/toml.h
+++ b/toml.h
@@ -27,7 +27,19 @@
 
 
 #include <stdio.h>
+
+#if __cplusplus >= 201103L \
+    || __STDC_VERSION__ >= 199901L \
+    || _MSC_VER >= 1600
+
 #include <stdint.h>
+#include <stdbool.h>
+
+#else
+
+typedef __int64 int64_t;
+
+#endif
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
These basic changes are designed to port tomlc99 to VC6. Much of the code is altered to be C89 compliant, by moving declarations to the beginning of scopes, and replacing bool with int. A basic reimplementation of `strtoll` is added.

VC6-specific changes are not C89 compliant. `snprintf` is replaced with `_snprintf` (which isn't a problem because the non-compliant return value is ignored). The `int64_t` type is a typedef to `__int64`.