### PR TITLE
Adding libtoml.pc for pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ HFILES = toml.h
 CFILES = toml.c
 OBJ = $(CFILES:.c=.o)
 EXEC = toml_json toml_cat toml_sample
+PCFILE = libtoml.pc
 
 CFLAGS = -std=c99 -Wall -Wextra -fpic
 LIB_VERSION = 1.0
@@ -41,6 +42,7 @@ install: all
 	install toml.h ${prefix}/include
 	install $(LIB) ${prefix}/lib
 	install $(LIB_SHARED) ${prefix}/lib
+	install $(PCFILE) /usr/lib/pkgconfig
 
 clean:
 	rm -f *.o $(EXEC) $(LIB) $(LIB_SHARED)

--- a/libtoml.pc
+++ b/libtoml.pc
@@ -1,0 +1,11 @@
+prefix=/usr/local/
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: libtoml
+URL: https://github.com/cktan/tomlc99/
+Description: TOML C library in c99.
+Version: v1.0
+Libs: -L${libdir} -ltoml
+Cflags: -I${includedir} 


### PR DESCRIPTION
I created a file for `toml` to be usable with [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) this will help build using `gcc -o myproject myproject.c $(pkg-config --cflags --libs libtoml)` 