### PR TITLE
Get rid of MSVC warnings

### DIFF
--- a/toml.c
+++ b/toml.c
@@ -220,8 +220,8 @@ int toml_ucs_to_utf8(int64_t code, char buf[6]) {
      110xxxxx 10xxxxxx
   */
   if (code <= 0x000007FF) {
-    buf[0] = 0xc0 | (code >> 6);
-    buf[1] = 0x80 | (code & 0x3f);
+    buf[0] = (unsigned char) (0xc0 | (code >> 6));
+    buf[1] = (unsigned char) (0x80 | (code & 0x3f));
     return 2;
   }
 
@@ -229,9 +229,9 @@ int toml_ucs_to_utf8(int64_t code, char buf[6]) {
      1110xxxx 10xxxxxx 10xxxxxx
   */
   if (code <= 0x0000FFFF) {
-    buf[0] = 0xe0 | (code >> 12);
-    buf[1] = 0x80 | ((code >> 6) & 0x3f);
-    buf[2] = 0x80 | (code & 0x3f);
+    buf[0] = (unsigned char) (0xe0 | (code >> 12));
+    buf[1] = (unsigned char) (0x80 | ((code >> 6) & 0x3f));
+    buf[2] = (unsigned char) (0x80 | (code & 0x3f));
     return 3;
   }
 
@@ -239,10 +239,10 @@ int toml_ucs_to_utf8(int64_t code, char buf[6]) {
      11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
   */
   if (code <= 0x001FFFFF) {
-    buf[0] = 0xf0 | (code >> 18);
-    buf[1] = 0x80 | ((code >> 12) & 0x3f);
-    buf[2] = 0x80 | ((code >> 6) & 0x3f);
-    buf[3] = 0x80 | (code & 0x3f);
+    buf[0] = (unsigned char) (0xf0 | (code >> 18));
+    buf[1] = (unsigned char) (0x80 | ((code >> 12) & 0x3f));
+    buf[2] = (unsigned char) (0x80 | ((code >> 6) & 0x3f));
+    buf[3] = (unsigned char) (0x80 | (code & 0x3f));
     return 4;
   }
 
@@ -250,11 +250,11 @@ int toml_ucs_to_utf8(int64_t code, char buf[6]) {
      111110xx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
   */
   if (code <= 0x03FFFFFF) {
-    buf[0] = 0xf8 | (code >> 24);
-    buf[1] = 0x80 | ((code >> 18) & 0x3f);
-    buf[2] = 0x80 | ((code >> 12) & 0x3f);
-    buf[3] = 0x80 | ((code >> 6) & 0x3f);
-    buf[4] = 0x80 | (code & 0x3f);
+    buf[0] = (unsigned char) (0xf8 | (code >> 24));
+    buf[1] = (unsigned char) (0x80 | ((code >> 18) & 0x3f));
+    buf[2] = (unsigned char) (0x80 | ((code >> 12) & 0x3f));
+    buf[3] = (unsigned char) (0x80 | ((code >> 6) & 0x3f));
+    buf[4] = (unsigned char) (0x80 | (code & 0x3f));
     return 5;
   }
 
@@ -262,12 +262,12 @@ int toml_ucs_to_utf8(int64_t code, char buf[6]) {
      1111110x 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
   */
   if (code <= 0x7FFFFFFF) {
-    buf[0] = 0xfc | (code >> 30);
-    buf[1] = 0x80 | ((code >> 24) & 0x3f);
-    buf[2] = 0x80 | ((code >> 18) & 0x3f);
-    buf[3] = 0x80 | ((code >> 12) & 0x3f);
-    buf[4] = 0x80 | ((code >> 6) & 0x3f);
-    buf[5] = 0x80 | (code & 0x3f);
+    buf[0] = (unsigned char) (0xfc | (code >> 30));
+    buf[1] = (unsigned char) (0x80 | ((code >> 24) & 0x3f));
+    buf[2] = (unsigned char) (0x80 | ((code >> 18) & 0x3f));
+    buf[3] = (unsigned char) (0x80 | ((code >> 12) & 0x3f));
+    buf[4] = (unsigned char) (0x80 | ((code >> 6) & 0x3f));
+    buf[5] = (unsigned char) (0x80 | (code & 0x3f));
     return 6;
   }
 
@@ -1496,6 +1496,7 @@ toml_table_t *toml_parse_file(FILE *fp, char *errbuf, int errbufsz) {
     int n = fread(buf + off, 1, bufsz - off, fp);
     if (ferror(fp)) {
       snprintf(errbuf, errbufsz, "%s",
+      #pragma warning(suppress : 4996)
                errno ? strerror(errno) : "Error reading file");
       xfree(buf);
       return 0;


### PR DESCRIPTION
Trying to compile the library using MSVC throws these warnings:

_warning C4244: '=': conversion from 'int64_t' to 'char', possible loss of data
warning C4244: '=': conversion from 'int64_t' to 'char', possible loss of data
warning C4244: '=': conversion from 'int64_t' to 'char', possible loss of data
warning C4244: '=': conversion from 'int64_t' to 'char', possible loss of data
warning C4244: '=': conversion from 'int64_t' to 'char', possible loss of data
warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead._

**[C4244](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=msvc-170)** fix is to explicitly cast result to `(unsigned byte)`
**[C4996](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=msvc-170)** is just disabled because thread-safe implementations are platform dependent and i guess it is not needed if you didn't impement it already. (`strerror_s `and `strerror_r`, Windows and Unix respectively.

These changes do not affect building with gcc on Unix but fixes warning with MSVC on Windows so anyone can just attach your library with their own CMakeLists to their project and build without any unnecessary warnings.