### PR TITLE
MSVC 4996 warning disabling pragma

### DIFF
--- a/toml.h
+++ b/toml.h
@@ -25,6 +25,10 @@
 #ifndef TOML_H
 #define TOML_H
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4996)
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 


### PR DESCRIPTION
This is a proper solution (a fix for #72 pragma problem) to disable the warning which does not produce any gcc warnings. 