### PR TITLE
Allow reading of line numbers of tables, arrays and keys.

### DIFF
--- a/line_number_sample.toml
+++ b/line_number_sample.toml
@@ -1,0 +1,6 @@
+[[fruit]]
+    name = "Banana"
+    price = 1.1
+
+[[fruit]]
+    name = "Orange"

--- a/line_number_sample.toml
+++ b/line_number_sample.toml
@@ -4,3 +4,7 @@
 
 [[fruit]]
     name = "Orange"
+
+[[fruit]]
+    name = "Carrot"
+    price = 1.2

--- a/toml.c
+++ b/toml.c
@@ -1922,6 +1922,11 @@ int toml_table_lineno(const toml_table_t *tab) {
   return tab->lineno;
 }
 
+
+int toml_array_lineno(const toml_array_t *arr) {
+  return arr->lineno;
+}
+
 toml_raw_t toml_raw_in(const toml_table_t *tab, const char *key) {
   int i;
   for (i = 0; i < tab->nkval; i++) {

--- a/toml.h
+++ b/toml.h
@@ -150,6 +150,10 @@ TOML_EXTERN int toml_table_ntab(const toml_table_t *tab);
 /* Return the key of a table*/
 TOML_EXTERN const char *toml_table_key(const toml_table_t *tab);
 
+TOML_EXTERN int toml_key_lineno(const toml_table_t *tab, const char *key);
+
+TOML_EXTERN int toml_table_lineno(const toml_table_t *tab);
+
 /*--------------------------------------------------------------
  * misc
  */

--- a/toml.h
+++ b/toml.h
@@ -138,6 +138,8 @@ TOML_EXTERN char toml_array_type(const toml_array_t *arr);
 /* Return the key of an array */
 TOML_EXTERN const char *toml_array_key(const toml_array_t *arr);
 
+TOML_EXTERN int toml_array_lineno(const toml_array_t *arr);
+
 /* Return the number of key-values in a table */
 TOML_EXTERN int toml_table_nkval(const toml_table_t *tab);
 

--- a/toml_line_number_example.c
+++ b/toml_line_number_example.c
@@ -1,0 +1,54 @@
+#include "toml.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void fatal(const char *msg, const char *msg1) {
+  fprintf(stderr, "ERROR: %s%s\n", msg, msg1 ? msg1 : "");
+  exit(1);
+}
+
+
+int main() {
+  FILE *fp;
+  char errbuf[200];
+
+  // 1. Read and parse toml file
+  fp = fopen("line_number_sample.toml", "r");
+  if (!fp) {
+    fatal("cannot open line_number_sample.toml - ", strerror(errno));
+  }
+
+  toml_table_t *conf = toml_parse_file(fp, errbuf, sizeof(errbuf));
+  fclose(fp);
+
+  if (!conf) {
+    fatal("cannot parse - ", errbuf);
+  }
+
+  // 2. Traverse to an array of fruit.
+  toml_array_t *fruits = toml_array_in(conf, "fruit");
+  if (!fruits) {
+    fatal("missing [fruit] table", "");
+  }
+  printf("Found fruit table starting at line: %d\n",toml_key_lineno(conf,"fruit"));
+
+  toml_table_t * first_fruit = toml_table_at(fruits,1);
+  
+  toml_datum_t name = toml_string_in(first_fruit, "price");
+  if (!name.ok) {
+    fprintf(stderr, "Fruit at line: %d did not specify a price.\n",toml_table_lineno(first_fruit));
+    
+  }
+
+  printf("Found fruit with name: %s\n",name.u.s);
+
+  // This could be an example message to the user;
+//   printf("Could not find : %d\n",toml_key_lineno(conf,"fruits"));
+
+
+  // I do not free because it exist immediately 
+
+  return 0;
+}

--- a/toml_line_number_example.c
+++ b/toml_line_number_example.c
@@ -34,21 +34,24 @@ int main() {
   }
   printf("Found fruit table starting at line: %d\n",toml_key_lineno(conf,"fruit"));
 
-  toml_table_t * first_fruit = toml_table_at(fruits,1);
+  toml_table_t * second_fruit = toml_table_at(fruits,1);
   
-  toml_datum_t name = toml_string_in(first_fruit, "price");
+  toml_datum_t name = toml_string_in(second_fruit, "price");
   if (!name.ok) {
-    fprintf(stderr, "Fruit at line: %d did not specify a price.\n",toml_table_lineno(first_fruit));
-    
+    fprintf(stderr, "Fruit at line: %d did not specify a price.\n",toml_table_lineno(second_fruit));
   }
 
-  printf("Found fruit with name: %s\n",name.u.s);
+  toml_table_t * third_fruit = toml_table_at(fruits,2);
+  toml_datum_t third_name = toml_string_in(third_fruit,"name");
+  if (!third_name.ok) {
+    fputs("Problem with example toml file",stderr);
+    exit(EXIT_FAILURE);
+  }
 
-  // This could be an example message to the user;
-//   printf("Could not find : %d\n",toml_key_lineno(conf,"fruits"));
-
-
-  // I do not free because it exist immediately 
+  if (strcmp(third_name.u.s,"carrot")) {
+    fprintf(stderr, "Fruit name at line: %d was not a permitted value.\n",toml_key_lineno(third_fruit,"name"));
+  }
+  // I do not free stuff because it exits immediately 
 
   return 0;
 }


### PR DESCRIPTION
Apologies as this is quite rough and needs some review, but this is a PR for issue #74.

I hacked together two files just for demo purposes, they can be safely deleted:
`toml_line_number_example.c` and `line_number_sample.toml`

The one I did struggle with is getting the line_no directly on `toml_datum_t` as it is created from a `toml_raw_t` which I don't want to change into a struct from `const char *`.  Instead you have to use `toml_key_lineno` for this.