### PR TITLE
expose table and array typedef in the header file

### DIFF
--- a/toml.c
+++ b/toml.c
@@ -275,53 +275,6 @@ int toml_ucs_to_utf8(int64_t code, char buf[6]) {
   return -1;
 }
 
-/*
- *	TOML has 3 data structures: value, array, table.
- *	Each of them can have identification key.
- */
-typedef struct toml_keyval_t toml_keyval_t;
-struct toml_keyval_t {
-  const char *key; /* key to this value */
-  const char *val; /* the raw value */
-};
-
-typedef struct toml_arritem_t toml_arritem_t;
-struct toml_arritem_t {
-  int valtype; /* for value kind: 'i'nt, 'd'ouble, 'b'ool, 's'tring, 't'ime,
-                  'D'ate, 'T'imestamp */
-  char *val;
-  toml_array_t *arr;
-  toml_table_t *tab;
-};
-
-struct toml_array_t {
-  const char *key; /* key to this array */
-  int kind;        /* element kind: 'v'alue, 'a'rray, or 't'able, 'm'ixed */
-  int type;        /* for value kind: 'i'nt, 'd'ouble, 'b'ool, 's'tring, 't'ime,
-                      'D'ate, 'T'imestamp, 'm'ixed */
-
-  int nitem; /* number of elements */
-  toml_arritem_t *item;
-};
-
-struct toml_table_t {
-  const char *key; /* key to this table */
-  bool implicit;   /* table was created implicitly */
-  bool readonly;   /* no more modification allowed */
-
-  /* key-values in the table */
-  int nkval;
-  toml_keyval_t **kval;
-
-  /* arrays in the table */
-  int narr;
-  toml_array_t **arr;
-
-  /* tables in the table */
-  int ntab;
-  toml_table_t **tab;
-};
-
 static inline void xfree(const void *x) {
   if (x)
     FREE((void *)(intptr_t)x);

--- a/toml.h
+++ b/toml.h
@@ -31,6 +31,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 #define TOML_EXTERN extern "C"
@@ -74,6 +75,53 @@ struct toml_timestamp_t {
   int *year, *month, *day;
   int *hour, *minute, *second, *millisec;
   char *z;
+};
+
+/*
+ *	TOML has 3 data structures: value, array, table.
+ *	Each of them can have identification key.
+ */
+typedef struct toml_keyval_t toml_keyval_t;
+struct toml_keyval_t {
+  const char *key; /* key to this value */
+  const char *val; /* the raw value */
+};
+
+typedef struct toml_arritem_t toml_arritem_t;
+struct toml_arritem_t {
+  int valtype; /* for value kind: 'i'nt, 'd'ouble, 'b'ool, 's'tring, 't'ime,
+                  'D'ate, 'T'imestamp */
+  char *val;
+  toml_array_t *arr;
+  toml_table_t *tab;
+};
+
+struct toml_array_t {
+  const char *key; /* key to this array */
+  int kind;        /* element kind: 'v'alue, 'a'rray, or 't'able, 'm'ixed */
+  int type;        /* for value kind: 'i'nt, 'd'ouble, 'b'ool, 's'tring, 't'ime,
+                      'D'ate, 'T'imestamp, 'm'ixed */
+
+  int nitem; /* number of elements */
+  toml_arritem_t *item;
+};
+
+struct toml_table_t {
+  const char *key; /* key to this table */
+  bool implicit;   /* table was created implicitly */
+  bool readonly;   /* no more modification allowed */
+
+  /* key-values in the table */
+  int nkval;
+  toml_keyval_t **kval;
+
+  /* arrays in the table */
+  int narr;
+  toml_array_t **arr;
+
+  /* tables in the table */
+  int ntab;
+  toml_table_t **tab;
 };
 
 /*-----------------------------------------------------------------


### PR DESCRIPTION
I know that we already have accessors for table and array, but exposing these type definitions can help to debug when building FFI bindings. Submit this issue and looking forward to your suggestion.

cc @cktan 

See https://github.com/ziglang/zig/issues/15788.