### PR TITLE
Add check target to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 toml_cat
 toml_json
 toml_sample
+unittest/t1
 
 # Debug files
 *.dSYM/

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ libtoml.so.$(LIB_VERSION): toml.o
 
 $(EXEC): $(LIB)
 
+check:
+	make -C unittest
+	./unittest/t1
+
 install: all
 	install -d ${prefix}/include ${prefix}/lib
 	install toml.h ${prefix}/include


### PR DESCRIPTION
This is to make it easy for distributions to run the unit tests when compiling the library.