### PR TITLE
Fix toml_json.c output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you are looking for a C++ library, you might try this wrapper: [https://githu
 
 * Compatible with [TOML v1.0.0](https://toml.io/en/v1.0.0).
 * Tested with multiple test suites, including
-[BurntSushi/toml-test](https://github.com/BurntSushi/toml-test) and
+[toml-lang/toml-test](https://github.com/toml-lang/toml-test) and
 [iarna/toml-spec-tests](https://github.com/iarna/toml-spec-tests).
 * Provides very simple and intuitive interface.
 
@@ -174,7 +174,7 @@ Alternatively, specify `make install prefix=/a/file/path` to install into
 
 ## Testing
 
-To test against the standard test set provided by BurntSushi/toml-test:
+To test against the standard test set provided by toml-lang/toml-test:
 
 ```sh
 % make

--- a/test1/build.sh
+++ b/test1/build.sh
@@ -1,9 +1,6 @@
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-mkdir -p $DIR/goworkspace
-export GOPATH=$DIR/goworkspace
-go get github.com/BurntSushi/toml-test@latest # install test suite
-go install github.com/BurntSushi/toml/cmd/toml-test-decoder@latest # e.g., install my parser
-cp $GOPATH/bin/* .
-
+export GOBIN=$DIR
+go install github.com/toml-lang/toml-test/cmd/toml-test@latest # install test suite

--- a/test1/run.sh
+++ b/test1/run.sh
@@ -1,5 +1,5 @@
+#!/usr/bin/env bash
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-rm -f tests
-ln -s ./goworkspace/pkg/mod/github.com/\!burnt\!sushi/toml-test@v0.1.0/tests
-./toml-test  ../toml_json
+$DIR/toml-test $DIR/../toml_json

--- a/test2/build.sh
+++ b/test2/build.sh
@@ -1,6 +1,7 @@
+#!/usr/bin/env bash
+
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 [ -d toml-spec-tests ] || git clone https://github.com/cktan/toml-spec-tests.git
-

--- a/test2/run.sh
+++ b/test2/run.sh
@@ -1,4 +1,6 @@
-if ! (which jq >& /dev/null); then 
+#!/usr/bin/env bash
+
+if ! (which jq >& /dev/null); then
     echo "ERROR: please install the 'jq' utility"
     exit 1
 fi
@@ -12,11 +14,11 @@ for i in toml-spec-tests/values/*.toml; do
     fname="${fname%.*}"
     echo -n $fname ' '
     res='[OK]'
-    if (../toml_json $fname.toml >& $fname.json.out); then 
+    if (../toml_json $fname.toml >& $fname.json.out); then
         jq -S . $fname.json.out > t.json
 	mv t.json $fname.json.out
 	if [ -f $fname.json ]; then
-	    if ! (diff $fname.json $fname.json.out >& /dev/null); then 
+	    if ! (diff $fname.json $fname.json.out >& /dev/null); then
 	        res='[FAILED]'
 	    else
 		rm -f $fname.json.out
@@ -32,10 +34,10 @@ done
 #
 #  NEGATIVE tests
 #
-for i in toml-spec-tests/errors/*.toml; do 
+for i in toml-spec-tests/errors/*.toml; do
     echo -n $i ' '
     res='[OK]'
-    if (../toml_json $i >& $i.json.out); then 
+    if (../toml_json $i >& $i.json.out); then
 	res='[FAILED]'
     fi
     echo ... $res


### PR DESCRIPTION
There were two issues; partly related to changes in upstream toml-test:

- Use appropriate type for local date and times.

- The arrays would get printed as:

      {"type": "array", "value": [...the values...]}

  But this should just be:

      [...the values...]

  It also wouldn't print mixed arrays because 'm' was missing in the switch; I adapted this from toml_cat.c.

Before:

	toml-test [./toml_json]: using embedded tests: 328 passed, 87 failed

After:

	toml-test [./toml_json]: using embedded tests: 351 passed, 64 failed

The remaining test failures look like a few minor issues in toml.c, rather than toml_json.c