### PR TITLE
meson: Add basic meson build definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,26 @@ Invoking `make install` will install the header and library files into
 Alternatively, specify `make install prefix=/a/file/path` to install into
 /a/file/path/{include,lib}.
 
+You can also use standard `meson` commands to compile and install. To build:
+
+```sh
+$ meson setup obj
+$ ninja -C obj
+```
+
+and to install (by default: the shared library, headers, and `pkg-config`
+metadata):
+
+```sh
+$ ninja -C obj install
+```
+
+to configure for a static build instead:
+
+```sh
+$ meson setup --default-library=static obj
+```
+
 ## Testing
 
 To test against the standard test set provided by toml-lang/toml-test:

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,35 @@
+project(
+    'tomlc99', 'c',
+    meson_version: '>= 0.47.0',
+    version: 'v1.0',
+    license: 'MIT',
+    default_options: [
+        'warning_level=2',
+        'c_std=c99',
+    ],
+)
+
+toml_sources = ['toml.c']
+toml_headers = ['toml.h']
+
+libtoml = library('toml',
+    sources: toml_sources,
+    install: true,
+    version: '1.0',
+)
+
+install_headers(toml_headers)
+
+libtoml_dep = declare_dependency(
+    include_directories: include_directories('.'),
+    link_with: libtoml,
+)
+
+pkg = import('pkgconfig')
+pkg.generate(libtoml,
+    filebase: meson.project_name(),
+    name: meson.project_name(),
+    version: meson.project_version(),
+    description: 'TOML parser in c99; v1.0 compliant',
+    url: 'https://github.com/cktan/tomlc99',
+)


### PR DESCRIPTION
Add a simple meson.build file to build and install a library (shared by default, but easily configurable as static too), headers and `libtoml.pc` metadata.

    $ meson setup --prefix=$PWD/install obj
    [...]
    $ ninja -C obj
    ninja: Entering directory `obj'
    [2/2] Linking target libtoml.so
    $ ninja -C obj install
    ninja: Entering directory `obj'
    [0/1] Installing files.
    Installing libtoml.so to /home/jk/devel/tomlc99/install/lib/x86_64-linux-gnu
    Installing /home/jk/devel/tomlc99/toml.h to /home/jk/devel/tomlc99/install/include/
    Installing /home/jk/devel/tomlc99/obj/meson-private/tomlc99.pc to /home/jk/devel/tomlc99/install/lib/x86_64-linux-gnu/pkgconfig
    $ find install/ -type f -o -type l
    install/include/toml.h
    install/lib/x86_64-linux-gnu/libtoml.so
    install/lib/x86_64-linux-gnu/libtoml.so.1
    install/lib/x86_64-linux-gnu/libtoml.so.1.0
    install/lib/x86_64-linux-gnu/pkgconfig/tomlc99.pc

We're mirroring the naming used by the existing Makefile here; project name is `tomlc99`, library name is `libtoml`.