### PR TITLE
added toml_kind_* to inspect item types

### DIFF
--- a/toml.h
+++ b/toml.h
@@ -42,6 +42,7 @@ typedef struct toml_timestamp_t toml_timestamp_t;
 typedef struct toml_table_t toml_table_t;
 typedef struct toml_array_t toml_array_t;
 typedef struct toml_datum_t toml_datum_t;
+typedef enum toml_kind_t toml_kind_t;
 
 /* Parse a file. Return a table on success, or 0 otherwise.
  * Caller must toml_free(the-return-value) after use.
@@ -89,6 +90,22 @@ struct toml_datum_t {
     double d;             /* double value */
   } u;
 };
+
+enum toml_kind_t {
+  TOML_KIND_UNKNOWN = 'u',
+  TOML_KIND_STRING = 's',
+  TOML_KIND_INT    = 'i',
+  TOML_KIND_BOOL   = 'b',
+  TOML_KIND_DOUBLE = 'd',
+  TOML_KIND_TABLE  = 'B',
+  TOML_KIND_ARRAY  = 'a',
+  TOML_KIND_DATE   = 'D',
+  TOML_KIND_TIME   = 't',
+  TOML_KIND_TIMESTAMP = 'T',
+  TOML_KIND_MIXED = 'm',
+  TOML_KIND_VALUE = 'v',
+};
+
 
 /* on arrays: */
 /* ... retrieve size of array. */
@@ -149,6 +166,12 @@ TOML_EXTERN int toml_table_ntab(const toml_table_t *tab);
 
 /* Return the key of a table*/
 TOML_EXTERN const char *toml_table_key(const toml_table_t *tab);
+
+TOML_EXTERN toml_kind_t toml_kind_at(const toml_array_t *arr, int idx);
+TOML_EXTERN toml_kind_t toml_kind_in(const toml_table_t *tab, const char* key);
+TOML_EXTERN int toml_kind_one_of_at(const toml_array_t *arr, int idx, const char *kinds);
+TOML_EXTERN int toml_kind_one_of_in(const toml_table_t *tab, const char* key,
+                                            const char *kinds);
 
 /*--------------------------------------------------------------
  * misc


### PR DESCRIPTION
## Rationale
While using this for something I wanted to allow multiple types for an item, and more to the point, check that an item was one of a set of types. I found myself using an ugly idiom
where I was blindly trying `toml_*_in` and checking the result to know when it was the right type.

With access to the innards of the opaque types, this set of fairly straightforward functions allow a more elegant idiom:

```toml
# example.toml
name = "example"
major_version = 0
```

```c
// prog.c
#include <toml.h>

int main()
{
    // ... omitted for brevity ...
    toml_table_t* conf = toml_parse_file("example.toml", errbuf, sizeof(errbuf));
    // ... omitted for brevity ...

    printf("%c\n", toml_kind_in(conf, "name")); // 's'
    printf("%c\n", toml_kind_in(conf, "major_version")); // 'i'

    printf("%d\n", toml_kind_one_of_in(conf, "name", "sid"); // 1
    printf("%d\n", toml_kind_one_of_in(conf, "name", "id"); // 0
    
}
```

##

Adds a new `toml_kind_t` type:

```c
enum toml_kind_t {
  TOML_KIND_UNKNOWN = 'u',
  TOML_KIND_STRING = 's',
  TOML_KIND_INT    = 'i',
  TOML_KIND_BOOL   = 'b',
  TOML_KIND_DOUBLE = 'd',
  TOML_KIND_TABLE  = 'B', // changed from previous version
  TOML_KIND_ARRAY  = 'a',
  TOML_KIND_DATE   = 'D',
  TOML_KIND_TIME   = 't',
  TOML_KIND_TIMESTAMP = 'T',
  TOML_KIND_MIXED = 'm',
  TOML_KIND_VALUE = 'v',
};
```

Unfortunately `TOML_KIND_TABLE` had to be disambiguated with `TOML_KIND_ARRAY`, and now functions that used to return `'t'` for table (like `toml_array_kind()`) now return `'B'`. I am not sure if this is the best solution.



